### PR TITLE
Case1126 fix error message

### DIFF
--- a/src/client/modules/route/topLevelError/topLevelError.html
+++ b/src/client/modules/route/topLevelError/topLevelError.html
@@ -1,7 +1,7 @@
 <template>
   <base-card>
     <base-illustration variant="WalkthroughNotAvailable" size="large" heading={errorMessage}>
-      <span slot="message">Please submit a request in the following <a href="/s/contactsupport" target="_blank">link</a> for help</span>
+      <span slot="message">Please submit a request in the following <a href="https://www.platformdemos.com/s/contactsupport" target="_blank">link</a> for help</span>
     </base-illustration>
   </base-card>
 </template>


### PR DESCRIPTION
Updating Deployer error page to not mention Shane's twitter handle but rather the contact support page on the site. This will allow users hitting errors to create a help request that routes to the platform demos team
Case link: https://platformmarketing.lightning.force.com/lightning/r/Case/5004p00000M8cysAAB/view